### PR TITLE
Code File Missing in Project

### DIFF
--- a/letsencrypt-win-simple/win-acme.csproj
+++ b/letsencrypt-win-simple/win-acme.csproj
@@ -339,6 +339,7 @@
     <Compile Include="Extensions\DateExtensions.cs" />
     <Compile Include="Extensions\SiteExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
+    <Compile Include="Extensions\TargetExtensions.cs" />
     <Compile Include="MainMenu.cs" />
     <Compile Include="Plugins\Base\BaseInstallationPluginFactory.cs" />
     <Compile Include="Plugins\Base\BasePluginFactory.cs" />


### PR DESCRIPTION
By merging #835 my additions broke the compilation, because the file `TargetExtensions.cs` is missing in the `.csproj`.