### PR TITLE
Add old certificate information to script installer

### DIFF
--- a/src/main.lib/Plugins/InstallationPlugins/Script/Script.cs
+++ b/src/main.lib/Plugins/InstallationPlugins/Script/Script.cs
@@ -35,6 +35,9 @@ namespace PKISharp.WACS.Plugins.InstallationPlugins
                 parameters = parameters.Replace("{5}", newCertificate.Certificate.Thumbprint);
                 parameters = parameters.Replace("{6}", newCertificate.CacheFile?.Directory.FullName);
                 parameters = parameters.Replace("{7}", _renewal.Id);
+                parameters = parameters.Replace("{8}", oldCertificate?.SubjectName);
+                parameters = parameters.Replace("{9}", oldCertificate?.Certificate.FriendlyName);
+                parameters = parameters.Replace("{10}", oldCertificate?.Certificate.Thumbprint);
 
                 parameters = parameters.Replace("{CachePassword}", _renewal.PfxPassword?.Value);
                 parameters = parameters.Replace("{CacheFile}", newCertificate.CacheFile?.FullName);
@@ -45,6 +48,10 @@ namespace PKISharp.WACS.Plugins.InstallationPlugins
                 parameters = parameters.Replace("{StoreType}", defaultStoreInfo.Name);
                 parameters = parameters.Replace("{StorePath}", defaultStoreInfo.Path);
                 parameters = parameters.Replace("{RenewalId}", _renewal.Id);
+                parameters = parameters.Replace("{OldCertCommonName}", oldCertificate?.SubjectName);
+                parameters = parameters.Replace("{OldCertFriendlyName}", oldCertificate?.Certificate.FriendlyName);
+                parameters = parameters.Replace("{OldCertThumbprint}", oldCertificate?.Certificate.Thumbprint);
+
                 await _client.RunScript(_options.Script, parameters);
             }
         }

--- a/src/main.lib/Plugins/InstallationPlugins/Script/Script.cs
+++ b/src/main.lib/Plugins/InstallationPlugins/Script/Script.cs
@@ -27,6 +27,9 @@ namespace PKISharp.WACS.Plugins.InstallationPlugins
                 var defaultStoreType = store.First().GetType();
                 var defaultStoreInfo = newCertificate.StoreInfo[defaultStoreType];
                 var parameters = _options.ScriptParameters ?? "";
+                
+                // Numbered parameters for backwards compatibility only,
+                // do not extend for future updates
                 parameters = parameters.Replace("{0}", newCertificate.CommonName);
                 parameters = parameters.Replace("{1}", _renewal.PfxPassword?.Value);
                 parameters = parameters.Replace("{2}", newCertificate.CacheFile?.FullName);
@@ -35,10 +38,7 @@ namespace PKISharp.WACS.Plugins.InstallationPlugins
                 parameters = parameters.Replace("{5}", newCertificate.Certificate.Thumbprint);
                 parameters = parameters.Replace("{6}", newCertificate.CacheFile?.Directory.FullName);
                 parameters = parameters.Replace("{7}", _renewal.Id);
-                parameters = parameters.Replace("{8}", oldCertificate?.SubjectName);
-                parameters = parameters.Replace("{9}", oldCertificate?.Certificate.FriendlyName);
-                parameters = parameters.Replace("{10}", oldCertificate?.Certificate.Thumbprint);
-
+  
                 parameters = parameters.Replace("{CachePassword}", _renewal.PfxPassword?.Value);
                 parameters = parameters.Replace("{CacheFile}", newCertificate.CacheFile?.FullName);
                 parameters = parameters.Replace("{CacheFolder}", newCertificate.CacheFile?.FullName);
@@ -48,7 +48,7 @@ namespace PKISharp.WACS.Plugins.InstallationPlugins
                 parameters = parameters.Replace("{StoreType}", defaultStoreInfo.Name);
                 parameters = parameters.Replace("{StorePath}", defaultStoreInfo.Path);
                 parameters = parameters.Replace("{RenewalId}", _renewal.Id);
-                parameters = parameters.Replace("{OldCertCommonName}", oldCertificate?.SubjectName);
+                parameters = parameters.Replace("{OldCertCommonName}", oldCertificate?.CommonName);
                 parameters = parameters.Replace("{OldCertFriendlyName}", oldCertificate?.Certificate.FriendlyName);
                 parameters = parameters.Replace("{OldCertThumbprint}", oldCertificate?.Certificate.Thumbprint);
 


### PR DESCRIPTION
Add script installer parameters for the old certificate's subject name, friendly name, and thumbprint.

Fixes #1435 


