### PR TITLE
Create common helper method to find best matching dns zone.

### DIFF
--- a/src/plugin.validation.dns.luadns/luadns.cs
+++ b/src/plugin.validation.dns.luadns/luadns.cs
@@ -78,7 +78,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
 
             var payload = await response.Content.ReadAsStringAsync();
             var zones = JsonSerializer.Deserialize<ZoneData[]>(payload);
-            var targetZone = zones.Where(d => recordName.EndsWith(d.Name, StringComparison.InvariantCultureIgnoreCase)).OrderByDescending(d => d.Name.Length).FirstOrDefault();
+            var targetZone = FindBestMatch(zones.ToDictionary(x => x.Name), recordName);
             if (targetZone == null)
             {
                 _log.Information("No matching zone found in LuaDNS account. Aborting");


### PR DESCRIPTION
Based on bugfixed code from Route53, thanks to @rvdginste (see https://github.com/win-acme/win-acme/pull/1525), but the same problem was in most other DNS plugins. Which meant it was high time to create a common helper which will always have the latest logic.

Would appreciate testing/verification for the various plugins.
@rvdginste 
@georg-jung (this one I'm most curious about, as the Cloudflare implementation didn't handle multiple result pages yet and only seemed to work for top-level domains, so the rewrite was a bit more drastic)
@albertofustinoni 
@vidarw 
@inkahootz

