### PR TITLE
Added ADFS import script

### DIFF
--- a/dist/Scripts/ImportADFS.ps1
+++ b/dist/Scripts/ImportADFS.ps1
@@ -1,0 +1,73 @@
+<#
+.SYNOPSIS
+Imports a cert from WACS renewal into Active Directory Federation Services
+.DESCRIPTION
+Note that this script is intended to be run via the install script plugin from win-acme via the batch script wrapper. As such, we use positional parameters to avoid issues with using a dash in the cmd line. 
+Note that this script only works on the primary ADFS farm server; you need to make sure to copy the certificates over yourself.
+
+Proper information should be available here
+
+https://github.com/PKISharp/win-acme/wiki/Install-Script
+
+or more generally, here
+
+https://github.com/PKISharp/win-acme/wiki/Example-Scripts
+
+.PARAMETER NewCertThumbprint
+The exact thumbprint of the cert to be imported. The script will copy this cert to the Personal store if not already there. 
+
+
+.EXAMPLE 
+
+ImportADFS.ps1 <certThumbprint>
+
+.NOTES
+
+#>
+
+param(
+    [Parameter(Position=0,Mandatory=$true)]
+    [string]$NewCertThumbprint
+)
+
+$CertInStore = Get-ChildItem -Path Cert:\LocalMachine -Recurse | Where-Object {$_.thumbprint -eq $NewCertThumbprint} | Sort-Object -Descending | Select-Object -f 1
+if($CertInStore){
+    try{
+        # Cert must exist in the personal store of machine to bind to ADFS
+        if($CertInStore.PSPath -notlike "*LocalMachine\My\*"){
+            $SourceStoreScope = 'LocalMachine'
+            $SourceStorename = $CertInStore.PSParentPath.split("\")[-1]
+
+            $SourceStore = New-Object  -TypeName System.Security.Cryptography.X509Certificates.X509Store  -ArgumentList $SourceStorename, $SourceStoreScope
+            $SourceStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadOnly)
+            
+            $cert = $SourceStore.Certificates | Where-Object {$_.thumbprint -eq $CertInStore.Thumbprint}
+            
+            
+            
+            $DestStoreScope = 'LocalMachine'
+            $DestStoreName = 'My'
+            
+            $DestStore = New-Object  -TypeName System.Security.Cryptography.X509Certificates.X509Store  -ArgumentList $DestStoreName, $DestStoreScope
+            $DestStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
+            $DestStore.Add($cert)
+            
+            
+            $SourceStore.Close()
+            $DestStore.Close()
+
+            $CertInStore = Get-ChildItem -Path Cert:\LocalMachine\My -Recurse | Where-Object {$_.thumbprint -eq $NewCertThumbprint} | Sort-Object -Descending | Select-Object -f 1
+        }
+
+        Set-AdfsCertificate -CertificateType Service-Communications -Thumbprint $CertInStore.Thumbprint -ErrorAction Stop
+        Set-AdfsSslCertificate -Thumbprint $CertInStore.Thumbprint -ErrorAction Stop
+        Restart-Service adfssrv -Force -ErrorAction Stop
+        "Cert thumbprint set to ADFS and service restarted"
+    }catch{
+        "Cert thumbprint was not set successfully"
+        "Error: $($Error[0])"
+    }
+}else{
+    "Cert thumbprint not found in the cert store... which is strange because it should be there."
+}
+


### PR DESCRIPTION
Added an import script for ADFS.
Notes:
- Copy the certificate to all servers in the ADFS farm before running this script; this script does not handle that
- Before WS16 you should run this script on all servers; WS16+ you should run this script only on the primary server in the farm.