### PR TITLE
Add minimal User-Agent Header to AcmeClient

### DIFF
--- a/src/main.lib/Clients/Acme/AcmeClient.cs
+++ b/src/main.lib/Clients/Acme/AcmeClient.cs
@@ -86,6 +86,7 @@ namespace PKISharp.WACS.Clients.Acme
 
             var httpClient = _proxyService.GetHttpClient();
             httpClient.BaseAddress = _settings.BaseUri;
+            httpClient.DefaultRequestHeaders.Add("User-Agent", "win-acme");
             var client = PrepareClient(httpClient, signer);
             try
             {


### PR DESCRIPTION
It is considered polite for a HTTP-Client to provide a very short identification.


Simple and minimal PR for sending a User-Agent. There are numerous options for improvement
(Number one: Also send the current Version)

### Previous Issue:

**Describe the bug**
`wacs.exe` does not send a User-Agent HTTP-Header with ACME-Requests

**To Reproduce**
Just run it against a HTTP Server and inspect the incoming Requests

**Expected behavior**
User-Agent of the form `win-acme@VERSION` or something like that

**Additional context**
We are running an internal home-grown ACME-Server and would like an overview of used clients to automatically notify users of Security Issues/general New Versions of their Clients.

