### PR TITLE
Fix exception when records need to be created without a name on DigitalOcean

### DIFF
--- a/src/plugin.validation.dns.digitalocean/DigitalOcean.cs
+++ b/src/plugin.validation.dns.digitalocean/DigitalOcean.cs
@@ -51,7 +51,10 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
                 var createdRecord = await _doClient.DomainRecords.Create(zone, new DomainRecord
                 {
                     Type = "TXT",
-                    Name = record.Authority.Domain[..^(zone.Length + 1)],
+                    // If a zone exists that has the exact name of the record to be created, the record needs to be named "@"
+                    Name = record.Authority.Domain == zone
+                        ? "@"
+                        : record.Authority.Domain[..^(zone.Length + 1)],
                     Data = record.Value,
                     Ttl = 300
                 });

--- a/src/plugin.validation.dns.digitalocean/DigitalOcean.cs
+++ b/src/plugin.validation.dns.digitalocean/DigitalOcean.cs
@@ -51,10 +51,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
                 var createdRecord = await _doClient.DomainRecords.Create(zone, new DomainRecord
                 {
                     Type = "TXT",
-                    // If a zone exists that has the exact name of the record to be created, the record needs to be named "@"
-                    Name = record.Authority.Domain == zone
-                        ? "@"
-                        : record.Authority.Domain[..^(zone.Length + 1)],
+                    Name = RelativeRecordName(zone, record.Authority.Domain),
                     Data = record.Value,
                     Ttl = 300
                 });


### PR DESCRIPTION
I encountered an exception with the DigitalOcean validation plugin while using it with an rather advanced setup.

I have a zone called `review.skulblaka.ch` which is a substitute for a zone I do not have and will not get write access.  
Because of that, I have delegated the acme validation to another zone at DigitalOcean using CNAME records:
```
_acme-challenge.review.skulblaka.ch. 3600 IN NS	ns1.digitalocean.com.
_acme-challenge.review.skulblaka.ch. 3600 IN NS	ns2.digitalocean.com.
_acme-challenge.review.skulblaka.ch. 3600 IN NS	ns3.digitalocean.com.
```

This caused the following exception:

```
 [VERB] Verbose mode logging enabled
 [VERB] ExePath: C:\Users\alexanderm\Downloads\win-acme.v2.1.12.943.x64.pluggable\wacs.exe
 [VERB] ResourcePath: C:\Users\alexanderm\Downloads\win-acme.v2.1.12.943.x64.pluggable
 [VERB] Loaded validation plugin DigitalOcean from C:\Users\alexanderm\Downloads\win-acme.v2.1.12.943.x64.pluggable\PKISharp.WACS.Plugins.ValidationPlugins.DigitalOcean.dll
 [VERB] Looking for settings.json in C:\Users\alexanderm\Downloads\win-acme.v2.1.12.943.x64.pluggable
 [DBUG] Config folder: C:\ProgramData\win-acme\acme-staging-v02.api.letsencrypt.org
 [DBUG] Log path: C:\ProgramData\win-acme\acme-staging-v02.api.letsencrypt.org\Log
 [DBUG] Cache path: C:\ProgramData\win-acme\acme-staging-v02.api.letsencrypt.org\Certificates
 [VERB] Arguments: --verbose --test --target manual --host *.review.skulblaka.ch --validationmode dns-01 --validation digitalocean --validation digitalocean --digitaloceanapitoken [REDACTED] --emailaddress [REDACTED] --store pemfiles --pemfilespath .
 [WARN] Found 1 files older than 120 days in cache path 'C:\ProgramData\win-acme\acme-staging-v02.api.letsencrypt.org\Certificates'
 [DBUG] Renewal period: 55 days
 [VERB] Sending e-mails False

 [INFO] A simple Windows ACMEv2 client (WACS)
 [INFO] Software version 2.1.12.943 (RELEASE, PLUGGABLE, 64-bit)
 [INFO] ACME server https://acme-staging-v02.api.letsencrypt.org/
 [VERB] SecurityProtocol setting: SystemDefault
 [DBUG] Send GET request to https://acme-staging-v02.api.letsencrypt.org/directory
 [VERB] Request completed with status OK
 [DBUG] Connection OK!
 [INFO] IIS version 10.0
 [INFO] Running with administrator credentials
 [WARN] Scheduled task points to different location for .exe and/or working directory
 [WARN] Scheduled task exists but does not look healthy
 [INFO] Please report issues at https://github.com/win-acme/win-acme
 [VERB] Test for international support: 語言 язык لغة
 [INFO] Running in mode: Unattended, Test
 [VERB] Adding 8.8.8.8 as DNS server
 [VERB] Adding 1.1.1.1 as DNS server
 [VERB] Adding 8.8.4.4 as DNS server
 [INFO] Target generated using plugin Manual: *.review.skulblaka.ch

 [VERB] Targeted convert into 1 order(s)
 [VERB] Checking [Manual] *.review.skulblaka.ch
 [VERB] Handle order 1/1: Main
 [VERB] Creating order for hosts: ["*.review.skulblaka.ch"]
 [VERB] Loading ACME account signer...
 [DBUG] Loading signer from C:\ProgramData\win-acme\acme-staging-v02.api.letsencrypt.org\Signer_v2
 [VERB] Constructing ACME protocol client...
 [DBUG] Send GET request to https://acme-staging-v02.api.letsencrypt.org/directory
 [VERB] Request completed with status OK
 [DBUG] Send HEAD request to https://acme-staging-v02.api.letsencrypt.org/acme/new-nonce
 [VERB] Request completed with status OK
 [VERB] Loading ACME account
 [DBUG] Loading account information from C:\ProgramData\win-acme\acme-staging-v02.api.letsencrypt.org\Registration_v2
 [VERB] ACME client initialized
 [DBUG] Send POST request to https://acme-staging-v02.api.letsencrypt.org/acme/new-order
 [VERB] Request completed with status Created
 [VERB] Order https://acme-staging-v02.api.letsencrypt.org/acme/order/[REDACTED] created
 [DBUG] Send POST request to https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/[REDACTED]
 [VERB] Request completed with status OK
 [VERB] Handle authorization 1/1
 [INFO] [review.skulblaka.ch] Cached authorization result: valid
 [INFO] [review.skulblaka.ch] Handling challenge anyway because --test and/or --force is active
 [INFO] [review.skulblaka.ch] Authorizing...
 [VERB] [review.skulblaka.ch] Initial authorization status: valid
 [VERB] [review.skulblaka.ch] Challenge types available: ["dns-01"]
 [VERB] [review.skulblaka.ch] Initial challenge status: valid
 [INFO] [review.skulblaka.ch] Authorizing using dns-01 validation (DigitalOcean)
 [VERB] Querying server 8.8.8.8 about ch
 [DBUG] Querying name servers for ch
 [VERB] Querying IP for name server
 [VERB] Name server IP 194.0.17.1 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 130.59.31.43 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 130.59.31.41 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 194.0.1.40 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 194.146.106.10 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 74.116.178.40 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 85.119.5.230 identified
 [VERB] Querying server 130.59.31.41 about skulblaka.ch
 [DBUG] Querying name servers for skulblaka.ch
 [VERB] Querying IP for name server
 [VERB] Name server IP 192.174.68.104 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 176.97.158.104 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 213.239.206.103 identified
 [VERB] Querying server 213.239.206.103 about review.skulblaka.ch
 [DBUG] Querying name servers for review.skulblaka.ch
 [VERB] Querying IP for name server
 [VERB] Name server IP 176.97.158.104 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 213.239.206.103 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 192.174.68.104 identified
 [VERB] Querying server 176.97.158.104 about _acme-challenge.review.skulblaka.ch
 [DBUG] Querying name servers for _acme-challenge.review.skulblaka.ch
 [VERB] Querying IP for name server
 [VERB] Name server IP 173.245.58.51 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 173.245.59.41 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 198.41.222.173 identified
 [DBUG] [review.skulblaka.ch] Attempting to create DNS record under _acme-challenge.review.skulblaka.ch...
 [VERB] Zone _acme-challenge.review.skulblaka.ch scored 4 points
 [VERB] Zone [REDACTED] not matched
 [VERB] Zone [REDACTED] not matched
 [VERB] Zone [REDACTED] not matched
 [VERB] Zone [REDACTED] not matched
 [VERB] Zone [REDACTED] not matched
 [VERB] Zone [REDACTED] not matched
 [VERB] Zone [REDACTED] not matched
 [VERB] Zone [REDACTED] not matched
 [DBUG] Picked _acme-challenge.review.skulblaka.ch as best match
 [EROR] Failed to create DNS record on DigitalOcean.
System.ArgumentOutOfRangeException: Length cannot be less than zero. (Parameter 'length')
   at System.String.Substring(Int32 startIndex, Int32 length)
   at PKISharp.WACS.Plugins.ValidationPlugins.Dns.DigitalOcean.CreateRecord(DnsValidationRecord record)
 [DBUG] [review.skulblaka.ch] Failed to create record under _acme-challenge.review.skulblaka.ch
 [EROR] [review.skulblaka.ch] Error preparing for challenge answer
System.Exception: [review.skulblaka.ch] Unable to prepare for challenge answer
   at PKISharp.WACS.Plugins.ValidationPlugins.DnsValidation`1.PrepareChallenge(ValidationContext context, Dns01ChallengeValidationDetails challenge)
   at PKISharp.WACS.Plugins.ValidationPlugins.Validation`1.PrepareChallenge(ValidationContext context)
   at PKISharp.WACS.RenewalValidator.PrepareChallengeAnswer(ValidationContext context, RunLevel runLevel)
```

After debugging, I found line `DigitalOcean.cs:56` to be the problem:
```csharp
Name = record.Authority.Domain[..^(zone.Length + 1)],
```

Since both `record.Authority.Domain` and `zone` were equal to `_acme-challenge.review.skulblaka.ch`, the range expression evaluated to `-1`, causing an `IndexOutOfRangeException`.

I added a check handling this case, now it works like a charm:

```
 [VERB] Verbose mode logging enabled
 [VERB] ExePath: C:\Users\alexanderm\source\repos\github.com\win-acme\win-acme\src\main\bin\Debug\netcoreapp3.1\wacs.exe
 [VERB] ResourcePath: C:\Users\alexanderm\source\repos\github.com\win-acme\win-acme\src\main\bin\Debug\netcoreapp3.1
 [VERB] Loaded validation plugin DigitalOcean from C:\Users\alexanderm\source\repos\github.com\win-acme\win-acme\src\main\bin\Debug\netcoreapp3.1\PKISharp.WACS.Plugins.ValidationPlugins.DigitalOcean.dll
 [VERB] Looking for settings.json in C:\Users\alexanderm\source\repos\github.com\win-acme\win-acme\src\main\bin\Debug\netcoreapp3.1
 [DBUG] Config folder: C:\ProgramData\win-acme\acme-staging-v02.api.letsencrypt.org
 [DBUG] Log path: C:\ProgramData\win-acme\acme-staging-v02.api.letsencrypt.org\Log
 [DBUG] Cache path: C:\ProgramData\win-acme\acme-staging-v02.api.letsencrypt.org\Certificates
 [VERB] Arguments: --verbose --test --target manual --host *.review.skulblaka.ch --validationmode dns-01 --validation digitalocean --validation digitalocean --digitaloceanapitoken [REDACTED] --emailaddress [REDACTED] --store pemfiles --pemfilespath .
 [WARN] Found 1 files older than 120 days in cache path 'C:\ProgramData\win-acme\acme-staging-v02.api.letsencrypt.org\Certificates'
 [DBUG] Renewal period: 55 days
 [VERB] Sending e-mails False

 [INFO] A simple Windows ACMEv2 client (WACS)
 [INFO] Software version 2.1.0.0 (DEBUG, PLUGGABLE, 64-bit)
 [INFO] ACME server https://acme-staging-v02.api.letsencrypt.org/
 [VERB] SecurityProtocol setting: SystemDefault
 [DBUG] Send GET request to https://acme-staging-v02.api.letsencrypt.org/directory
 [VERB] Request completed with status OK
 [DBUG] Connection OK!
 [INFO] IIS version 10.0
 [WARN] Running without administrator credentials, some options disabled
 [WARN] Scheduled task not configured yet
 [INFO] Please report issues at https://github.com/win-acme/win-acme
 [VERB] Test for international support: 語言 язык لغة
 [INFO] Running in mode: Unattended, Test
 [VERB] Adding 8.8.8.8 as DNS server
 [VERB] Adding 1.1.1.1 as DNS server
 [VERB] Adding 8.8.4.4 as DNS server
 [INFO] Target generated using plugin Manual: *.review.skulblaka.ch
 [WARN] No write access to all renewals: Access to the path 'C:\ProgramData\win-acme\acme-staging-v02.api.letsencrypt.org\[REDACTED].renewal.json' is denied.

 [VERB] Targeted convert into 1 order(s)
 [VERB] Checking [Manual] *.review.skulblaka.ch
 [VERB] Handle order 1/1: Main
 [VERB] Creating order for hosts: ["*.review.skulblaka.ch"]
 [VERB] Loading ACME account signer...
 [DBUG] Loading signer from C:\ProgramData\win-acme\acme-staging-v02.api.letsencrypt.org\Signer_v2
 [VERB] Constructing ACME protocol client...
 [DBUG] Send GET request to https://acme-staging-v02.api.letsencrypt.org/directory
 [VERB] Request completed with status OK
 [DBUG] Send HEAD request to https://acme-staging-v02.api.letsencrypt.org/acme/new-nonce
 [VERB] Request completed with status OK
 [VERB] Loading ACME account
 [DBUG] Loading account information from C:\ProgramData\win-acme\acme-staging-v02.api.letsencrypt.org\Registration_v2
 [VERB] ACME client initialized
 [DBUG] Send POST request to https://acme-staging-v02.api.letsencrypt.org/acme/new-order
 [VERB] Request completed with status Created
 [VERB] Order https://acme-staging-v02.api.letsencrypt.org/acme/order/[REDACTED]/[REDACTED]created
 [DBUG] Send POST request to https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/[REDACTED]
 [VERB] Request completed with status OK
 [VERB] Handle authorization 1/1
 [INFO] [review.skulblaka.ch] Cached authorization result: valid
 [INFO] [review.skulblaka.ch] Handling challenge anyway because --test and/or --force is active
 [INFO] [review.skulblaka.ch] Authorizing...
 [VERB] [review.skulblaka.ch] Initial authorization status: valid
 [VERB] [review.skulblaka.ch] Challenge types available: ["dns-01"]
 [VERB] [review.skulblaka.ch] Initial challenge status: valid
 [INFO] [review.skulblaka.ch] Authorizing using dns-01 validation (DigitalOcean)
 [VERB] Querying server 8.8.8.8 about ch
 [DBUG] Querying name servers for ch
 [VERB] Querying IP for name server
 [VERB] Name server IP 130.59.31.41 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 130.59.31.43 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 74.116.178.40 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 194.0.17.1 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 194.146.106.10 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 194.0.1.40 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 85.119.5.230 identified
 [VERB] Querying server 85.119.5.230 about skulblaka.ch
 [DBUG] Querying name servers for skulblaka.ch
 [VERB] Querying IP for name server
 [VERB] Name server IP 192.174.68.104 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 176.97.158.104 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 213.239.206.103 identified
 [VERB] Querying server 192.174.68.104 about review.skulblaka.ch
 [DBUG] Querying name servers for review.skulblaka.ch
 [VERB] Querying IP for name server
 [VERB] Name server IP 192.174.68.104 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 213.239.206.103 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 176.97.158.104 identified
 [VERB] Querying server 176.97.158.104 about _acme-challenge.review.skulblaka.ch
 [DBUG] Querying name servers for _acme-challenge.review.skulblaka.ch
 [VERB] Querying IP for name server
 [VERB] Name server IP 173.245.58.51 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 173.245.59.41 identified
 [VERB] Querying IP for name server
 [VERB] Name server IP 198.41.222.173 identified
 [DBUG] [review.skulblaka.ch] Attempting to create DNS record under _acme-challenge.review.skulblaka.ch...
 [VERB] Zone _acme-challenge.review.skulblaka.ch scored 4 points
 [VERB] Zone [REDACTED] not matched
 [VERB] Zone [REDACTED] not matched
 [VERB] Zone [REDACTED] not matched
 [VERB] Zone [REDACTED] not matched
 [VERB] Zone [REDACTED] not matched
 [VERB] Zone [REDACTED] not matched
 [VERB] Zone [REDACTED] not matched
 [VERB] Zone [REDACTED] not matched
 [DBUG] Picked _acme-challenge.review.skulblaka.ch as best match
 [DBUG] [review.skulblaka.ch] Record succesfully created
 [VERB] Starting commit stage
 [DBUG] [review.skulblaka.ch] Looking for TXT value _acme-challenge.review.skulblaka.ch...
 [DBUG] [review.skulblaka.ch] Preliminary validation asking 173.245.58.51...
 [DBUG] [review.skulblaka.ch] Preliminary validation from 173.245.58.51 looks good
 [DBUG] [review.skulblaka.ch] Preliminary validation asking 173.245.59.41...
 [DBUG] [review.skulblaka.ch] Preliminary validation from 173.245.59.41 looks good
 [DBUG] [review.skulblaka.ch] Preliminary validation asking 198.41.222.173...
 [DBUG] [review.skulblaka.ch] Preliminary validation from 198.41.222.173 looks good
 [INFO] [review.skulblaka.ch] Preliminary validation succeeded
 [VERB] Commit was succesful
 [DBUG] [review.skulblaka.ch] Submitting challenge answer
 [DBUG] Send POST request to https://acme-staging-v02.api.letsencrypt.org/acme/chall-v3/[REDACTED]/[REDACTED]
 [VERB] Request completed with status OK
 [INFO] [review.skulblaka.ch] Authorization result: valid
 [VERB] Starting post-validation cleanup
 [INFO] Successfully deleted DNS record on DigitalOcean.
 [VERB] Post-validation cleanup was succesful
```