### PR TITLE
Add hosted zone option to azure dns validation

### DIFF
--- a/src/plugin.validation.dns.azure/Azure.cs
+++ b/src/plugin.validation.dns.azure/Azure.cs
@@ -42,16 +42,14 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
         /// Allow this plugin to process multiple validations at the same time.
         /// They will still be prepared and cleaned in serial order though not
         /// to overwhelm the DnsManagementClient or risk threads overwriting 
-        /// eachothers changes.
+        /// each others changes.
         /// </summary>
         public override ParallelOperations Parallelism => ParallelOperations.Answer;
 
         /// <summary>
         /// Create record in Azure DNS
         /// </summary>
-        /// <param name="context"></param>
-        /// <param name="recordName"></param>
-        /// <param name="token"></param>
+        /// <param name="record"></param>
         /// <returns></returns>
         public override async Task<bool> CreateRecord(DnsValidationRecord record)
         {
@@ -107,7 +105,6 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
         /// </summary>
         /// <param name="zone"></param>
         /// <param name="domain"></param>
-        /// <param name="recordSet"></param>
         /// <returns></returns>
         private async Task CreateOrUpdateRecordSet(string zone, string domain)
         {
@@ -166,12 +163,17 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
         }
 
         /// <summary>
-        /// Find the approriate hosting zone to use for record updates
+        /// Find the appropriate hosting zone to use for record updates
         /// </summary>
         /// <param name="recordName"></param>
         /// <returns></returns>
         private async Task<string> GetHostedZone(string recordName)
         {
+            if (!string.IsNullOrEmpty(_options.HostedZone))
+            {
+                return _options.HostedZone;
+            }
+
             // Cache so we don't have to repeat this more than once for each renewal
             if (_hostedZones == null)
             {
@@ -207,7 +209,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
         public override Task DeleteRecord(DnsValidationRecord record) => Task.CompletedTask;
 
         /// <summary>
-        /// Clear created createds
+        /// Clear created
         /// </summary>
         /// <returns></returns>
         public override async Task Finalize() =>

--- a/src/plugin.validation.dns.azure/AzureArguments.cs
+++ b/src/plugin.validation.dns.azure/AzureArguments.cs
@@ -7,5 +7,6 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins
     {
         public string AzureResourceGroupName { get; set; }
         public string AzureSubscriptionId { get; set; }
+        public string AzureHostedZone { get; set; }
     }
 }

--- a/src/plugin.validation.dns.azure/AzureOptions.cs
+++ b/src/plugin.validation.dns.azure/AzureOptions.cs
@@ -23,5 +23,6 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
 
         public string SubscriptionId { get; set; }
         public string TenantId { get; set; }
+        public string HostedZone { get; set; }
     }
 }

--- a/src/plugin.validation.dns.azure/AzureOptionsFactory.cs
+++ b/src/plugin.validation.dns.azure/AzureOptionsFactory.cs
@@ -24,6 +24,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
             await common.Aquire(options);
             options.ResourceGroupName = await _arguments.TryGetArgument(az.AzureResourceGroupName, input, "DNS resource group name");
             options.SubscriptionId = await _arguments.TryGetArgument(az.AzureSubscriptionId, input, "Subscription id");
+            options.HostedZone = await _arguments.TryGetArgument(az.AzureHostedZone, input, "Hosted Zone (blank to find best match)");
             return options;
         }
 
@@ -35,6 +36,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
             await common.Default(options);
             options.ResourceGroupName = _arguments.TryGetRequiredArgument(nameof(az.AzureResourceGroupName), az.AzureResourceGroupName);
             options.SubscriptionId = _arguments.TryGetRequiredArgument(nameof(az.AzureSubscriptionId), az.AzureSubscriptionId);
+            options.HostedZone = _arguments.TryGetRequiredArgument(nameof(az.AzureHostedZone), az.AzureHostedZone);
             return options;
         }
 


### PR DESCRIPTION
Hello,

This pull request will allow the user to optionally provide the azure hosted zone in which to create the _acme-challenge record set. The current behavior is to infer the hosted zone, and this requires a larger scope of permissions. 

Use Case
----------
I've locked down the permissions to only allow a vm access to the single record set (_acme-challenge) instead of the whole hosted zone, however win-acme does not accept a hosted zone parameter and infers it based on the hosted zones it has permissions to and fails as it does not have access to any hosted zones. 

Ref: https://docs.microsoft.com/en-us/azure/dns/dns-protect-zones-recordsets#record-set-level-azure-rbac

Let me know if you have any questions and thanks for the excellent project.

Cheers,
Cory.