### PR TITLE
Update PSScript.bat

### DIFF
--- a/dist/Scripts/PSScript.bat
+++ b/dist/Scripts/PSScript.bat
@@ -4,4 +4,4 @@ REM Spaces are not supported in script path
 REM Also, in testing, powershell script must use positional parameters. Results may vary
 REM Ex. "./Scripts/PSScript.bat c:\scripts\test.ps1 value"
 
-powershell.exe -ExecutionPolicy RemoteSigned -File %*
+pwsh -ExecutionPolicy RemoteSigned -File %*


### PR DESCRIPTION
Support for PowerShell 7. Since PowerShell 5.1 is .Net Framework, the path forward is PowerShell 7 and onwards.
Obviously this requires the installation of PowerShell on the device the tool is running on.


