### PR TITLE
Remove Duplicate Command From ImportRDSFull.ps1

### DIFF
--- a/dist/Scripts/ImportRDSFull.ps1
+++ b/dist/Scripts/ImportRDSFull.ps1
@@ -54,7 +54,6 @@ if ($CertInStore)
         Set-Item -Path RDS:\GatewayServer\SSLCertificate\Thumbprint -Value $CertInStore.Thumbprint -ErrorAction Stop
         Restart-Service TSGateway -Force -ErrorAction Stop
         "Cert thumbprint set to RD Gateway listener and service restarted"
-		wmic /namespace:\\root\cimv2\TerminalServices PATH Win32_TSGeneralSetting Set SSLCertificateSHA1Hash="$($CertInStore.Thumbprint)"
     } 
 	catch 
 	{


### PR DESCRIPTION
An identical wmic command was included at the end of the try block for the RD Gateway cert configuration in addition to being the only active command in the subsequent RDP Listener try block.  Presumably the command should only be used in the latter try block so that its failure won't return the wrong error in the earlier try block.

As I haven't previously used GitHub, I also thought a simple pull request could be beneficial prior to providing a more complicated script if it turns out to be necessary after some additional testing on my multi-server RDS deployment.

In my previous testing, I actually skipped this entire try block because `Get-Item -Path RDS:\GatewayServer\SSLCertificate\Thumbprint` was retuning a null value for the thumbprint to begin with.  Running the same get command after finishing testing without running the set command on line 54 or the restart command on line 55 returned the correct thumbprint, so I'm also curious as to when/if the remaining part of this particular try block is even necessary.