### PR TITLE
Lower Hostname while checking existence

### DIFF
--- a/dist/Scripts/ImportWinRM.ps1
+++ b/dist/Scripts/ImportWinRM.ps1
@@ -57,9 +57,9 @@ if($CertInStore){
             $CertInStore = Get-ChildItem -Path Cert:\LocalMachine\My -Recurse | Where-Object {$_.thumbprint -eq $NewCertThumbprint} | Sort-Object -Descending | Select-Object -f 1
         }
         $winrm = 'winrm/config/listener'
-
-        Get-WSManInstance -ResourceURI $winrm -Enumerate | Where-Object {$CertInStore.DnsNameList -contains $_.Hostname} | ForEach-Object {Set-WSManInstance -ResourceURI $winrm -SelectorSet @{Address=$_.Address; Transport=$_.Transport} -ValueSet @{CertificateThumbprint=$CertInStore.Thumbprint}}
-
+        
+        Get-WSManInstance -ResourceURI $winrm -Enumerate | Where-Object {$CertInStore.DnsNameList -contains $_.Hostname.ToLower()} | ForEach-Object {Set-WSManInstance -ResourceURI $winrm -SelectorSet @{Address=$_.Address; Transport=$_.Transport} -ValueSet @{CertificateThumbprint=$CertInStore.Thumbprint}}
+        
         Restart-Service WinRM -Force -ErrorAction Stop
         "Cert thumbprint set to WinRM public HTTPS listener and service restarted"
     }catch{

--- a/dist/Scripts/ImportWinRM.v2.ps1
+++ b/dist/Scripts/ImportWinRM.v2.ps1
@@ -35,7 +35,7 @@ $CertInStore = Get-ChildItem -Path Cert:\LocalMachine -Recurse | Where-Object {$
 if($CertInStore){
     try{
         $winrm = 'winrm/config/listener'
-        $WinRmEndpoint = Get-WSManInstance -ResourceURI $winrm -Enumerate | Where-Object {$_.Transport -eq 'HTTPS' -and $CertInStore.DnsNameList -contains $_.Hostname}
+        $WinRmEndpoint = Get-WSManInstance -ResourceURI $winrm -Enumerate | Where-Object {$_.Transport -eq 'HTTPS' -and $CertInStore.DnsNameList -contains $_.Hostname.ToLower()}
 
         if($null -ne $WinRmEndpoint){
             $WinRmEndpoint | ForEach-Object {Set-WSManInstance -ResourceURI $winrm -SelectorSet @{Address=$_.Address; Transport=$_.Transport} -ValueSet @{CertificateThumbprint=$CertInStore.Thumbprint}}


### PR DESCRIPTION
We have - unfortunately - some capitalized Hostnames (think `WIN12345` or `SERV001`) which causes Binding after Issuing to fail.


This definitely has no negative effects for sane people/organizations who do not use capitalize Hostnames. For people using `win-acme` with capitalized Hostnames this should fix an existing problem.