### PR TITLE
Fix user prompt in unattended mode

### DIFF
--- a/src/main.lib/RenewalCreator.cs
+++ b/src/main.lib/RenewalCreator.cs
@@ -230,6 +230,7 @@ namespace PKISharp.WACS
                     goto retry;
                 }
                 if (!renewal.New && 
+                    runLevel.HasFlag(RunLevel.Interactive) &&
                     await _input.PromptYesNo("Save these new settings anyway?", false))
                 {
                     _renewalStore.Save(renewal, result);


### PR DESCRIPTION
Possible fix for #2043 

Skip "Save Settings" user prompt in unattended mode.