### PR TITLE
zone pages can contain up to 50 records

### DIFF
--- a/src/plugin.validation.dns.cloudflare/Cloudflare.cs
+++ b/src/plugin.validation.dns.cloudflare/Cloudflare.cs
@@ -46,7 +46,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
             while (allZones.Count < totalCount)
             {
                 page++;
-                var zonesResp = await context.Zones.List().Page(page).ParseAsync(_hc).ConfigureAwait(false);
+                var zonesResp = await context.Zones.List().PerPage(50).Page(page).ParseAsync(_hc).ConfigureAwait(false);
                 if (!zonesResp.Success || zonesResp.ResultInfo.Count == 0)
                 {
                     break;


### PR DESCRIPTION
Since it's a rate-limited API and our best matching algorithm requires retrieving all records, it would be a good practice to get more records with fewer requests. 

https://api.cloudflare.com/#zone-list-zones


