### PR TITLE
add the cmd file extension to the script installer

### DIFF
--- a/src/main.lib/Plugins/InstallationPlugins/Script/ScriptOptionsFactory.cs
+++ b/src/main.lib/Plugins/InstallationPlugins/Script/ScriptOptionsFactory.cs
@@ -21,7 +21,7 @@ namespace PKISharp.WACS.Plugins.InstallationPlugins
         private ArgumentResult<string?> Script => _arguments.
             GetString<ScriptArguments>(x => x.Script).
             Validate(x => Task.FromResult(x.ValidFile(_log)), "invalid path").
-            Validate(x => Task.FromResult(x!.EndsWith(".ps1") || x!.EndsWith(".exe") || x!.EndsWith(".bat")), "invalid extension").
+            Validate(x => Task.FromResult(x!.EndsWith(".ps1") || x!.EndsWith(".exe") || x!.EndsWith(".bat") || x!.EndsWith(".cmd")), "invalid extension").
             Required();
 
         private ArgumentResult<string?> Parameters => _arguments.


### PR DESCRIPTION
add the cmd file extension to the script installer as its basically the same as an .bat file
(not sure why github messed up the changes, the only change resides on line 24

