### PR TITLE
Fixing logging logic for email notifications

### DIFF
--- a/src/main.lib/Clients/EmailClient.cs
+++ b/src/main.lib/Clients/EmailClient.cs
@@ -126,6 +126,7 @@ namespace PKISharp.WACS.Clients
                         await client.SendAsync(message);
                     }                       
                     await client.DisconnectAsync(true);
+                    _log.Information("Test message sent!");
                 }
                 catch (Exception ex)
                 {
@@ -150,7 +151,6 @@ namespace PKISharp.WACS.Clients
                 await Send("Test notification",
                     "<p>If you are reading this, it means you will receive notifications about critical errors in the future.</p>",
                     MessagePriority.Normal);
-                _log.Information("Test message sent!");
             }
         }
     }


### PR DESCRIPTION
I have encounter this logic mistake while setting up my email notifications in `settings.json`.

With my settings (which are most probably wrong):
```
"Notification": {
    "SmtpServer": "myEmail@addr.com",
    "SmtpPort": 25,
    "SmtpUser": null,
    "SmtpPassword": null,
    "SmtpSecure": false,
    "SmtpSecureMode": 1,
    "SenderName": "DC",
    "SenderAddress": "myEmail@addr.com",
    "ReceiverAddresses": ["myEmail@addr.com","myEmail@addr.com","myEmail@addr.com"],
    "EmailOnSuccess": true,
    "ComputerName": null
  },
```

logging message was as follows:
```
 Sending test message...
 Problem sending e-mail
 Test message sent!
```
and slightly contradicting itself since no email was sent. Moving the `_log()` call at the end of the `Send` method should do the trick.