### PR TITLE
Fix the check, if certificate is already imported

### DIFF
--- a/src/main.lib/Plugins/StorePlugins/CertificateStore/CertificateStoreClient.cs
+++ b/src/main.lib/Plugins/StorePlugins/CertificateStore/CertificateStoreClient.cs
@@ -86,7 +86,7 @@ namespace PKISharp.WACS.Plugins.StorePlugins
             imStore ??= _store;
             foreach (var cert in chain)
             {
-                if (imStore.Certificates.Find(X509FindType.FindByThumbprint, cert.Thumbprint, false) == null)
+                if (imStore.Certificates.Find(X509FindType.FindByThumbprint, cert.Thumbprint, false).Count == 0)
                 {
                     try
                     {


### PR DESCRIPTION
X509Certificate2Collection.Find() will always return a new X509Certificate2Collection, even if no certificate matching the specified criteria was found. To check if the certificate is not already in the store, you have to check the count of certificates inside the collection.

This should fix #2373.
