### PR TITLE
Switched to JAVA_HOME environmental variable

### DIFF
--- a/dist/Scripts/ImportJKS.ps1
+++ b/dist/Scripts/ImportJKS.ps1
@@ -36,7 +36,9 @@ param(
 	$KeyStoreKeyPassword
 )
 
-Set-Alias keytool "C:\Program Files (x86)\Java\jre1.8.0_141\bin\keytool.exe"
+$keytoolpath = Join-Path -Path $env:JAVA_HOME -ChildPath bin\keytool.exe
+
+Set-Alias keytool $keytoolpath
 
 if ([string]::IsNullOrEmpty($KeyStoreKeyPassword)) 
 {


### PR DESCRIPTION
Changed the path to the keytool.exe from a hard link to use the JAVA_HOME Environmental variable, allowing non-default installs of Java to work with the script.

For Example: the Eclipse Adoptum install of OpenJDK installs to C:\Program Files\Eclipse Adoptium\jdk-8.0.###.#-hotspot\, and has the install option to set %JAVA_HOME% to that path.


