### PR TITLE
Update SSH.NET to 2023.0.0

### DIFF
--- a/src/main.lib/wacs.lib.csproj
+++ b/src/main.lib/wacs.lib.csproj
@@ -51,7 +51,7 @@
 		<PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
 		<PackageReference Include="Serilog.Sinks.EventLog" Version="3.1.0" />
 		<PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-		<PackageReference Include="SSH.NET" Version="2020.0.2" />
+		<PackageReference Include="SSH.NET" Version="2023.0.0" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
 		<PackageReference Include="System.Net.Http.WinHttpHandler" Version="7.0.0" />
 		<PackageReference Include="System.Security.Cryptography.ProtectedData" Version="7.0.1" />


### PR DESCRIPTION
Update SSH.NET to the latest version https://www.nuget.org/packages/SSH.NET/2023.0.0

## New features:
* Support for .NET 6, 7, and .NET Standard 2.0/2.1
* Support for RSA-SHA256/512 signature algorithms
* Support for parsing OpenSSH keys with ECDSA 256/384/521 and RSA
* Support for SHA256 and MD5 fingerprints for host key validation
* Added async support to SftpClient and SftpFileStream
* Added ISftpFile interface to SftpFile
* Removed support for old target frameworks
* Improved performance and stability
* Added the ability to set the last write and access time for Sftp files