### PR TITLE
feat: adds support for user-assigned managed identities

### DIFF
--- a/src/plugin.common.azure/AzureHelpers.cs
+++ b/src/plugin.common.azure/AzureHelpers.cs
@@ -50,13 +50,19 @@ namespace PKISharp.WACS.Plugins.Azure.Common
         public TokenCredential TokenCredential
         {
             get
-            {
-                return _options.UseMsi
-                      ? new ManagedIdentityCredential()
-                      : new ClientSecretCredential(
-                          _options.TenantId,
-                          _options.ClientId,
-                          _ssm.EvaluateSecret(_options.Secret?.Value));
+            { 
+                if (_options.UseMsi && string.IsNullOrEmpty(_options.ClientId)) {
+                    return new ManagedIdentityCredential();
+                } 
+                
+                if (_options.UseMsi && !string.IsNullOrEmpty(_options.ClientId)) {
+                    return new ManagedIdentityCredential(_options.ClientId);
+                } 
+
+                return new ClientSecretCredential(
+                        _options.TenantId,
+                        _options.ClientId,
+                        _ssm.EvaluateSecret(_options.Secret?.Value));
             }
         }
 


### PR DESCRIPTION
This will allow for using user-assigned managed identities when both the bool UseMsi and the ClientId are specified. 

Note, this matches the pattern for the az cli login: `az login --identity --username <client_id|object_id|resource_id>` (https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli-managed-identity)

I'd also be happy to update the docs. I'm not sure what your testing regime is like?