### PR TITLE
Update plugin.validation.dns.hetzner to supoort new hetzner cloud dns api

### DIFF
--- a/src/plugin.validation.dns.hetzner/Hetzner.cs
+++ b/src/plugin.validation.dns.hetzner/Hetzner.cs
@@ -1,15 +1,17 @@
-using PKISharp.WACS.Clients.DNS;
-using PKISharp.WACS.Plugins.Base.Capabilities;
-using PKISharp.WACS.Plugins.Interfaces;
-using PKISharp.WACS.Plugins.ValidationPlugins.Dns.Models;
-using PKISharp.WACS.Services;
 using System;
 using System.Linq;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
 
-[assembly: SupportedOSPlatform("windows")]
+using PKISharp.WACS.Clients.DNS;
+using PKISharp.WACS.Plugins.Base.Capabilities;
+using PKISharp.WACS.Plugins.Interfaces;
+using PKISharp.WACS.Services;
 
+using PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal;
+using PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal.Models;
+
+[assembly: SupportedOSPlatform("windows")]
 namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
 {
     [IPlugin.Plugin<
@@ -20,7 +22,8 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
     public class Hetzner : DnsValidation<Hetzner>, IDisposable
     {
         private readonly HetznerOptions _options;
-        private readonly HetznerClient _client;
+
+        private readonly IHetznerClient _client;
 
         public Hetzner(
             HetznerOptions options,
@@ -30,45 +33,21 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
             ILogService logService,
             ISettingsService settings) : base(dnsClient, logService, settings)
         {
-            _client = new HetznerClient(ssm.EvaluateSecret(options.ApiToken) ?? throw new InvalidOperationException("API Token cannot be null"), logService, proxyService);
+            if (options.UseHetznerCloud)
+            {
+                _client = new HetznerCloudDnsClient(ssm.EvaluateSecret(options.ApiToken) ?? throw new InvalidOperationException("API Token cannot be null"), logService, proxyService);
+            }
+            else
+            {
+                _client = new HetznerDnsClient(ssm.EvaluateSecret(options.ApiToken) ?? throw new InvalidOperationException("API Token cannot be null"), logService, proxyService);
+            }
+
             _options = options;
-        }
-
-        private async Task<Zone?> GetHostedZone(string recordName)
-        {
-            if (String.IsNullOrWhiteSpace(_options.ZoneId) is false)
-            {
-                _log.Debug("Using Zone Id specified by input arguments to get zone information.");
-
-                return await _client.GetZoneAsync(_options.ZoneId).ConfigureAwait(false);
-            }
-
-            _log.Debug($"Try getting best matching zone for record '{recordName}'.");
-
-            var zones = await _client.GetAllZonesAsync().ConfigureAwait(false);
-            if (zones.Count == 0)
-            {
-                _log.Error("No zones could be found using the Hetzner DNS API. " +
-                    "Maybe you entered a wrong API Token?");
-                throw new Exception();
-            }
-
-            var bestZone = FindBestMatch(zones.Where(x => x.Paused is false).ToDictionary(x => x.Name), recordName);
-            if (bestZone == null)
-            {
-                _log.Error($"No zone could be found that matches with record {recordName} and is not paused. " +
-                    $"Maybe the API Token does not allow access to your domain?");
-                throw new Exception();
-            }
-
-            _log.Information($"Best matching zone found: {bestZone.Name} - {bestZone.Status}");
-
-            return bestZone;
         }
 
         public override async Task<bool> CreateRecord(DnsValidationRecord record)
         {
-            var zone = await GetHostedZone(record.Authority.Domain).ConfigureAwait(false);
+            var zone = await this.GetHostedZone(record.Authority.Domain).ConfigureAwait(false);
             if (zone == null)
             {
                 _log.Error("The zone could not be found using the Hetzner DNS API, thus creating a DNS validation record is impossible. " +
@@ -79,7 +58,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
             }
 
             var host = record.Authority.Domain.Replace($".{zone.Name}", null);
-            var txtRecord = new Record("TXT", host, record.Value, zone.Id);
+            var txtRecord = new HetznerRecord("TXT", host, record.Value, zone.Id);
 
             return await _client.CreateRecordAsync(txtRecord).ConfigureAwait(false);
         }
@@ -88,7 +67,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
         {
             try
             {
-                var zone = await GetHostedZone(record.Authority.Domain).ConfigureAwait(false);
+                var zone = await this.GetHostedZone(record.Authority.Domain).ConfigureAwait(false);
                 if (zone == null)
                 {
                     _log.Error("The zone could not be found using the Hetzner DNS API, thus creating a DNS validation record is impossible. " +
@@ -99,7 +78,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
                 }
 
                 var host = record.Authority.Domain.Replace($".{zone.Name}", null);
-                var txtRecord = new Record("TXT", host, record.Value, zone.Id);
+                var txtRecord = new HetznerRecord("TXT", host, record.Value, zone.Id);
 
                 await _client.DeleteRecordAsync(txtRecord).ConfigureAwait(false);
             }
@@ -110,5 +89,37 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
         }
 
         public void Dispose() => _client.Dispose();
+
+        private async Task<HetznerZone?> GetHostedZone(string recordName)
+        {
+            if (String.IsNullOrWhiteSpace(_options.ZoneId) is false)
+            {
+                _log.Debug("Using Zone Id specified by input arguments to get zone information.");
+
+                return await _client.GetZoneAsync(_options.ZoneId).ConfigureAwait(false);
+            }
+
+            _log.Debug($"Try getting best matching zone for record '{recordName}'.");
+
+            var zones = await _client.GetAllActiveZonesAsync().ConfigureAwait(false);
+            if (zones.Count == 0)
+            {
+                _log.Error("No zones could be found using the Hetzner DNS API. " +
+                    "Maybe you entered a wrong API Token?");
+                throw new Exception();
+            }
+
+            var bestZone = FindBestMatch(zones.ToDictionary(x => x.Name), recordName);
+            if (bestZone == null)
+            {
+                _log.Error($"No zone could be found that matches with record {recordName} and is not paused. " +
+                    $"Maybe the API Token does not allow access to your domain?");
+                throw new Exception();
+            }
+
+            _log.Information($"Best matching zone found: {bestZone.Name}");
+
+            return bestZone;
+        }
     }
 }

--- a/src/plugin.validation.dns.hetzner/HetznerArguments.cs
+++ b/src/plugin.validation.dns.hetzner/HetznerArguments.cs
@@ -14,5 +14,8 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins
 
         [CommandLine(Description = "OPTIONAL: ID of zone the record is associated with.")]
         public string? HetznerZoneId { get; set; }
+
+        [CommandLine(Description = "Use the Hetzner Cloud API.")]
+        public bool UseHetznerCloud { get; set; }
     }
 }

--- a/src/plugin.validation.dns.hetzner/HetznerOptions.cs
+++ b/src/plugin.validation.dns.hetzner/HetznerOptions.cs
@@ -1,5 +1,6 @@
 ﻿using PKISharp.WACS.Plugins.Base.Options;
 using PKISharp.WACS.Services.Serialization;
+
 using System.Text.Json.Serialization;
 
 namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
@@ -15,5 +16,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
         public ProtectedString? ApiToken { get; set; }
 
         public string? ZoneId { get; set; }
+
+        public bool UseHetznerCloud { get; set; }
     }
 }

--- a/src/plugin.validation.dns.hetzner/HetznerOptionsFactory.cs
+++ b/src/plugin.validation.dns.hetzner/HetznerOptionsFactory.cs
@@ -19,7 +19,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
 
         private ArgumentResult<bool?> UseHetznerCloud => _arguments
             .GetBool<HetznerArguments>(a => a.UseHetznerCloud)
-            .WithDefault(true);
+            .WithDefault(false);
 
         private ArgumentResult<string?> ZoneId => _arguments
             .GetString<HetznerArguments>(a => a.HetznerZoneId)

--- a/src/plugin.validation.dns.hetzner/HetznerOptionsFactory.cs
+++ b/src/plugin.validation.dns.hetzner/HetznerOptionsFactory.cs
@@ -10,38 +10,42 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns
     public class HetznerOptionsFactory : PluginOptionsFactory<HetznerOptions>
     {
         private readonly ArgumentsInputService _arguments;
+
         public HetznerOptionsFactory(ArgumentsInputService arguments) => _arguments = arguments;
 
         private ArgumentResult<ProtectedString?> ApiKey => _arguments
             .GetProtectedString<HetznerArguments>(a => a.HetznerApiToken)
             .Required();
 
+        private ArgumentResult<bool?> UseHetznerCloud => _arguments
+            .GetBool<HetznerArguments>(a => a.UseHetznerCloud)
+            .WithDefault(true);
+
         private ArgumentResult<string?> ZoneId => _arguments
             .GetString<HetznerArguments>(a => a.HetznerZoneId)
             .DefaultAsNull();
 
         public override async Task<HetznerOptions?> Aquire(IInputService inputService, RunLevel runLevel)
-        {
-            return new HetznerOptions
+            => new HetznerOptions
             {
                 ApiToken = await ApiKey.Interactive(inputService, "Hetzner API Token").GetValue(),
-                ZoneId = await ZoneId.Interactive(inputService, "Hetzner Zone Id").GetValue()
+                ZoneId = await ZoneId.Interactive(inputService, "Hetzner Zone Id").GetValue(),
+                UseHetznerCloud = await UseHetznerCloud.Interactive(inputService, "Use Hetzner Cloud API").GetValue() ?? true
             };
-        }
 
         public override async Task<HetznerOptions?> Default()
-        {
-            return new HetznerOptions
+            => new HetznerOptions
             {
                 ApiToken = await ApiKey.GetValue(),
-                ZoneId = await ZoneId.GetValue()
+                ZoneId = await ZoneId.GetValue(),
+                UseHetznerCloud = await UseHetznerCloud.GetValue() ?? true,
             };
-        }
 
         public override IEnumerable<(CommandLineAttribute, object?)> Describe(HetznerOptions options)
         {
             yield return (ApiKey.Meta, options.ApiToken);
             yield return (ZoneId.Meta, options.ZoneId);
+            yield return (UseHetznerCloud.Meta, options.UseHetznerCloud);
         }
     }
 }

--- a/src/plugin.validation.dns.hetzner/Internal/HetznerCloudDnsClient.cs
+++ b/src/plugin.validation.dns.hetzner/Internal/HetznerCloudDnsClient.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Mime;
+using System.Threading.Tasks;
+
+using PKISharp.WACS.Services;
+using PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal.Models;
+using PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal.Models.HetznerCloud;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal;
+
+internal sealed class HetznerCloudDnsClient : IHetznerClient, IDisposable
+{
+    private static readonly Uri BASE_ADDRESS = new Uri("https://api.hetzner.cloud/v1/");
+
+    private ILogService log;
+
+    private HttpClient httpClient;
+
+    public HetznerCloudDnsClient(string apiToken, ILogService logService, IProxyService proxyService)
+    {
+        this.log = logService;
+
+        this.httpClient = proxyService.GetHttpClient();
+        this.httpClient.BaseAddress = BASE_ADDRESS;
+        this.httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {apiToken}");
+    }
+
+    public void Dispose()
+    {
+        this.httpClient.Dispose();
+    }
+
+    public async Task<IReadOnlyCollection<HetznerZone>> GetAllActiveZonesAsync()
+    {
+        var zonesResponse = await this.httpClient.GetFromJsonAsync<ZonesResponse>("zones").ConfigureAwait(false);
+        if (zonesResponse is null)
+        {
+            this.log.Warning("No zones found in Hetzner DNS");
+            return Array.Empty<HetznerZone>();
+        }
+
+        // Is only one page returned?
+        if (zonesResponse.Meta.Pagination.LastPage == zonesResponse.Meta.Pagination.Page)
+        {
+            return zonesResponse.Zones.Select(z => new HetznerZone(z.Id, z.Name)).ToImmutableArray();
+        }
+
+        var allZones = new List<Zone>();
+        allZones.AddRange(zonesResponse.Zones);
+
+        // As long as we are not on the last page continue
+        while (zonesResponse.Meta.Pagination.LastPage != zonesResponse.Meta.Pagination.Page)
+        {
+            var nextPage = zonesResponse.Meta.Pagination.Page + 1;
+
+            zonesResponse = await this.httpClient.GetFromJsonAsync<ZonesResponse>($"zones?page={nextPage}").ConfigureAwait(false);
+            if (zonesResponse is null)
+            {
+                this.log.Warning($"No zones found on page {nextPage} in Hetzner DNS");
+                return allZones.Select(z => new HetznerZone(z.Id, z.Name)).ToImmutableArray();
+            }
+
+            allZones.AddRange(zonesResponse.Zones);
+        }
+
+        return allZones.Select(z => new HetznerZone(z.Id, z.Name)).ToImmutableArray();
+    }
+
+    public async Task<HetznerZone?> GetZoneAsync(string zoneId)
+    {
+        var zoneResponse = await this.httpClient.GetFromJsonAsync<ZoneResponse>($"zones/{zoneId}").ConfigureAwait(false);
+        if (zoneResponse is null)
+        {
+            this.log.Warning($"Zone with zone id {zoneId} not found in Hetzner DNS");
+            return null;
+        }
+
+        return new HetznerZone(zoneResponse.Zone.Id, zoneResponse.Zone.Name);
+    }
+
+    public async Task<bool> CreateRecordAsync(HetznerRecord record)
+    {
+        var rrSet = new RRSet(record);
+        using var response = await this.httpClient.PostAsJsonAsync($"zones/{record.zone_id}/rrsets", rrSet).ConfigureAwait(false);
+
+        return response.IsSuccessStatusCode;
+    }
+
+    public async Task DeleteRecordAsync(HetznerRecord record)
+    {
+        using var deleteResponse = await this.httpClient.DeleteAsync($"zones/{record.zone_id}/rrsets/{record.name}/{record.type}").ConfigureAwait(false);
+
+        deleteResponse.EnsureSuccessStatusCode();
+    }
+}

--- a/src/plugin.validation.dns.hetzner/Internal/HetznerDnsClient.cs
+++ b/src/plugin.validation.dns.hetzner/Internal/HetznerDnsClient.cs
@@ -1,17 +1,20 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Net.Mime;
 using System.Threading.Tasks;
-using PKISharp.WACS.Plugins.ValidationPlugins.Dns.Models;
+
 using PKISharp.WACS.Services;
+using PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal.Models;
+using PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal.Models.HetznerDns;
 
-namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns;
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal;
 
-internal sealed class HetznerClient : IDisposable
+internal sealed class HetznerDnsClient : IHetznerClient, IDisposable
 {
     private static readonly Uri BASE_ADDRESS = new Uri("https://dns.hetzner.com/api/v1/");
 
@@ -19,7 +22,7 @@ internal sealed class HetznerClient : IDisposable
 
     private HttpClient _httpClient;
 
-    public HetznerClient(string apiToken, ILogService logService, IProxyService proxyService)
+    public HetznerDnsClient(string apiToken, ILogService logService, IProxyService proxyService)
     {
         _log = logService;
 
@@ -34,19 +37,19 @@ internal sealed class HetznerClient : IDisposable
         _httpClient.Dispose();
     }
 
-    public async Task<ICollection<Zone>> GetAllZonesAsync()
+    public async Task<IReadOnlyCollection<HetznerZone>> GetAllActiveZonesAsync()
     {
         var zonesResponse = await _httpClient.GetFromJsonAsync<ZonesResponse>("zones").ConfigureAwait(false);
         if (zonesResponse is null)
         {
             _log.Warning("No zones found in Hetzner DNS");
-            return Array.Empty<Zone>();
+            return Array.Empty<HetznerZone>();
         }
 
         // Is only one page returned?
         if (zonesResponse.Meta.Pagination.LastPage == zonesResponse.Meta.Pagination.Page)
         {
-            return zonesResponse.Zones;
+            return zonesResponse.Zones.Where(x => x.Paused is false).Select(z => new HetznerZone(z.Id, z.Name)).ToImmutableArray();
         }
 
         var allZones = new List<Zone>();
@@ -61,16 +64,16 @@ internal sealed class HetznerClient : IDisposable
             if (zonesResponse is null)
             {
                 _log.Warning($"No zones found on page {nextPage} in Hetzner DNS");
-                return allZones;
+                return allZones.Where(x => x.Paused is false).Select(z => new HetznerZone(z.Id, z.Name)).ToImmutableArray();
             }
 
             allZones.AddRange(zonesResponse.Zones);
         }
 
-        return allZones;
+        return allZones.Where(x => x.Paused is false).Select(z => new HetznerZone(z.Id, z.Name)).ToImmutableArray();
     }
 
-    public async Task<Zone?> GetZoneAsync(string zoneId)
+    public async Task<HetznerZone?> GetZoneAsync(string zoneId)
     {
         var zoneResponse = await _httpClient.GetFromJsonAsync<Zone>($"zones/{zoneId}").ConfigureAwait(false);
         if (zoneResponse is null)
@@ -79,17 +82,17 @@ internal sealed class HetznerClient : IDisposable
             return null;
         }
 
-        return zoneResponse;
+        return new HetznerZone(zoneResponse.Id, zoneResponse.Name);
     }
 
-    public async Task<bool> CreateRecordAsync(Record record)
+    public async Task<bool> CreateRecordAsync(HetznerRecord record)
     {
         using var response = await _httpClient.PostAsJsonAsync("records", record).ConfigureAwait(false);
 
         return response.IsSuccessStatusCode;
     }
 
-    public async Task DeleteRecordAsync(Record record)
+    public async Task DeleteRecordAsync(HetznerRecord record)
     {
         var recordSet = await _httpClient.GetFromJsonAsync<RecordResultSet>($"records?zone_id={record.zone_id}");
         if (recordSet is null || recordSet.records is null || recordSet.records.Length == 0)

--- a/src/plugin.validation.dns.hetzner/Internal/IHetznerClient.cs
+++ b/src/plugin.validation.dns.hetzner/Internal/IHetznerClient.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal.Models;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal;
+
+internal interface IHetznerClient : IDisposable
+{
+    Task<HetznerZone?> GetZoneAsync(string zoneId);
+
+    Task<IReadOnlyCollection<HetznerZone>> GetAllActiveZonesAsync();
+
+    Task<bool> CreateRecordAsync(HetznerRecord record);
+
+    Task DeleteRecordAsync(HetznerRecord record);
+}

--- a/src/plugin.validation.dns.hetzner/Internal/Models/HetznerCloud/Metadata.cs
+++ b/src/plugin.validation.dns.hetzner/Internal/Models/HetznerCloud/Metadata.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Models;
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal.Models.HetznerCloud;
 
 internal sealed class Metadata
 {

--- a/src/plugin.validation.dns.hetzner/Internal/Models/HetznerCloud/PaginationMetadata.cs
+++ b/src/plugin.validation.dns.hetzner/Internal/Models/HetznerCloud/PaginationMetadata.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Models;
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal.Models.HetznerCloud;
 
 internal sealed class PaginationMetadata
 {
@@ -11,10 +11,10 @@ internal sealed class PaginationMetadata
     public int PerPage { get; init; }
 
     [JsonPropertyName("previous_page")]
-    public int PreviousPage { get; init; }
+    public int? PreviousPage { get; init; }
 
     [JsonPropertyName("next_page")]
-    public int NextPage { get; init; }
+    public int? NextPage { get; init; }
 
     [JsonPropertyName("last_page")]
     public int LastPage { get; init; }

--- a/src/plugin.validation.dns.hetzner/Internal/Models/HetznerCloud/RRSet.cs
+++ b/src/plugin.validation.dns.hetzner/Internal/Models/HetznerCloud/RRSet.cs
@@ -1,0 +1,31 @@
+using System.Text.Json.Serialization;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal.Models.HetznerCloud;
+
+internal sealed class RRSet
+{
+    public RRSet(HetznerRecord record)
+    {
+        this.Name = record.name;
+        this.Type = record.type;
+        this.Ttl = record.ttl;
+        this.Records = new[]
+        {
+            new RecordValue($"\"{record.value}\"", "win-acme validation record")
+        };
+    }
+
+    [JsonPropertyName("name")]
+    public string Name { get; }
+
+    [JsonPropertyName("type")]
+    public string Type { get; }
+
+    [JsonPropertyName("ttl")]
+    public int Ttl { get; }
+
+    [JsonPropertyName("records")]
+    public RecordValue[] Records { get; set; }
+
+    internal record RecordValue(string value, string comment);
+}

--- a/src/plugin.validation.dns.hetzner/Internal/Models/HetznerCloud/Zone.cs
+++ b/src/plugin.validation.dns.hetzner/Internal/Models/HetznerCloud/Zone.cs
@@ -1,20 +1,17 @@
 using System.Text.Json.Serialization;
 
-namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Models;
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal.Models.HetznerCloud;
 
 internal sealed class Zone
 {
     [JsonPropertyName("id")]
-    public required string Id { get; init; }
+    public required int Id { get; init; }
 
     [JsonPropertyName("name")]
     public required string Name { get; init; }
 
-    [JsonPropertyName("paused")]
-    public bool Paused { get; init; }
-
     [JsonPropertyName("status")]
-    public required ZoneStatus Status { get; init; }
+    public required string Status { get; init; }
 
     [JsonPropertyName("ttl")]
     public required uint Ttl { get; init; }

--- a/src/plugin.validation.dns.hetzner/Internal/Models/HetznerCloud/ZoneResponse.cs
+++ b/src/plugin.validation.dns.hetzner/Internal/Models/HetznerCloud/ZoneResponse.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal.Models.HetznerCloud;
+
+internal sealed class ZoneResponse
+{
+    [JsonPropertyName("zone")]
+    public required Zone Zone { get; init; }
+}

--- a/src/plugin.validation.dns.hetzner/Internal/Models/HetznerCloud/ZonesResponse.cs
+++ b/src/plugin.validation.dns.hetzner/Internal/Models/HetznerCloud/ZonesResponse.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Models;
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal.Models.HetznerCloud;
 
 internal sealed class ZonesResponse
 {

--- a/src/plugin.validation.dns.hetzner/Internal/Models/HetznerDns/Metadata.cs
+++ b/src/plugin.validation.dns.hetzner/Internal/Models/HetznerDns/Metadata.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal.Models.HetznerDns;
+
+internal sealed class Metadata
+{
+    [JsonPropertyName("pagination")]
+    public required PaginationMetadata Pagination { get; init; }
+}

--- a/src/plugin.validation.dns.hetzner/Internal/Models/HetznerDns/PaginationMetadata.cs
+++ b/src/plugin.validation.dns.hetzner/Internal/Models/HetznerDns/PaginationMetadata.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal.Models.HetznerDns;
+
+internal sealed class PaginationMetadata
+{
+    [JsonPropertyName("page")]
+    public int Page { get; init; }
+
+    [JsonPropertyName("per_page")]
+    public int PerPage { get; init; }
+
+    [JsonPropertyName("previous_page")]
+    public int PreviousPage { get; init; }
+
+    [JsonPropertyName("next_page")]
+    public int NextPage { get; init; }
+
+    [JsonPropertyName("last_page")]
+    public int LastPage { get; init; }
+
+    [JsonPropertyName("total_entries")]
+    public int TotalEntries { get; init; }
+}

--- a/src/plugin.validation.dns.hetzner/Internal/Models/HetznerDns/Zone.cs
+++ b/src/plugin.validation.dns.hetzner/Internal/Models/HetznerDns/Zone.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal.Models.HetznerDns;
+
+internal sealed class Zone
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("paused")]
+    public bool Paused { get; init; }
+
+    [JsonPropertyName("status")]
+    public required ZoneStatus Status { get; init; }
+
+    [JsonPropertyName("ttl")]
+    public required uint Ttl { get; init; }
+}

--- a/src/plugin.validation.dns.hetzner/Internal/Models/HetznerDns/ZoneStatus.cs
+++ b/src/plugin.validation.dns.hetzner/Internal/Models/HetznerDns/ZoneStatus.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Models;
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal.Models.HetznerDns;
 
 [JsonConverter(typeof(JsonStringEnumConverter<ZoneStatus>))]
 internal enum ZoneStatus

--- a/src/plugin.validation.dns.hetzner/Internal/Models/HetznerDns/ZonesResponse.cs
+++ b/src/plugin.validation.dns.hetzner/Internal/Models/HetznerDns/ZonesResponse.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal.Models.HetznerDns;
+
+internal sealed class ZonesResponse
+{
+    [JsonPropertyName("zones")]
+    public required Zone[] Zones { get; init; }
+
+    [JsonPropertyName("meta")]
+    public required Metadata Meta { get; init; }
+}

--- a/src/plugin.validation.dns.hetzner/Internal/Models/HetznerRecord.cs
+++ b/src/plugin.validation.dns.hetzner/Internal/Models/HetznerRecord.cs
@@ -1,0 +1,3 @@
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal.Models;
+
+internal sealed record HetznerRecord(string type, string name, string value, string zone_id, int ttl = 3600);

--- a/src/plugin.validation.dns.hetzner/Internal/Models/HetznerZone.cs
+++ b/src/plugin.validation.dns.hetzner/Internal/Models/HetznerZone.cs
@@ -1,0 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Internal.Models;
+
+internal sealed record HetznerZone(string Id, string Name)
+{
+    [SetsRequiredMembers]
+    public HetznerZone(int id, string name)
+        : this(id.ToString(), name)
+        { }
+}

--- a/src/plugin.validation.dns.hetzner/Models/Record.cs
+++ b/src/plugin.validation.dns.hetzner/Models/Record.cs
@@ -1,3 +1,0 @@
-namespace PKISharp.WACS.Plugins.ValidationPlugins.Dns.Models;
-
-internal sealed record Record(string type, string name, string value, string zone_id, int ttl = 3600);


### PR DESCRIPTION
Hetzner is migrating its DNS Services to be managed by the Hetzner Cloud Console.
The cloud console comes with its own API. See:
https://docs.hetzner.com/networking/dns/migration-to-hetzner-console/process/

This PR adds support for the new API with an flag. It must be set to `true` to use the new cloud console API while the migration is still in progress, so that the user needs explicitly to opt in.

When the migration process is finished and hetzer shutdown the old API the legacy client will be removed and the DNS plugin will be cleaned up.