### PR TITLE
Simply: trailing slashes, surface API errors, idempotent cleanup

### DIFF
--- a/src/plugin.validation.dns.simply/Simply/SimplyDnsClient.cs
+++ b/src/plugin.validation.dns.simply/Simply/SimplyDnsClient.cs
@@ -58,6 +58,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Simply
         private async Task<List<Product>> GetProductsAsync()
         {
             using var response = await _httpClient.GetAsync(_baseUrl + "/my/products/");
+            await EnsureSuccessOrThrowAsync(response, "GET /my/products/");
             await using var stream = await response.Content.ReadAsStreamAsync();
             var products = await JsonSerializer.DeserializeAsync<ProductList>(stream);
             if (products == null || products.Products == null)
@@ -71,21 +72,19 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Simply
         {
             using var content = new StringContent(JsonSerializer.Serialize(record), Encoding.UTF8, "application/json");
             using var response = await _httpClient.PostAsync(_baseUrl + $"/my/products/{WebUtility.UrlEncode(objectId)}/dns/records/", content);
-            var responseBody = await response.Content.ReadAsStringAsync();
-            _ = response.EnsureSuccessStatusCode();
+            await EnsureSuccessOrThrowAsync(response, "POST /dns/records/");
         }
 
         private async Task DeleteRecordAsync(string objectId, int recordId)
         {
             using var response = await _httpClient.DeleteAsync(_baseUrl + $"/my/products/{WebUtility.UrlEncode(objectId)}/dns/records/{recordId}/");
-            var responseBody = await response.Content.ReadAsStringAsync();
-            _ = response.EnsureSuccessStatusCode();
+            await EnsureSuccessOrThrowAsync(response, $"DELETE /dns/records/{recordId}/");
         }
 
         private async Task<List<DnsRecord>> GetRecordsAsync(string objectId)
         {
             using var response = await _httpClient.GetAsync(_baseUrl + $"/my/products/{WebUtility.UrlEncode(objectId)}/dns/records/");
-            _ = response.EnsureSuccessStatusCode();
+            await EnsureSuccessOrThrowAsync(response, "GET /dns/records/");
             await using var stream = await response.Content.ReadAsStreamAsync();
             var records = await JsonSerializer.DeserializeAsync<DnsRecordList>(stream);
             if (records == null || records.Records == null)
@@ -93,6 +92,44 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Simply
                 throw new InvalidOperationException();
             }
             return records.Records;
+        }
+
+        private static async Task EnsureSuccessOrThrowAsync(HttpResponseMessage response, string operation)
+        {
+            if (response.IsSuccessStatusCode)
+            {
+                return;
+            }
+            var body = await response.Content.ReadAsStringAsync();
+            throw new HttpRequestException(
+                $"Simply.com API error ({operation}, HTTP {(int)response.StatusCode}): {ExtractErrorMessage(body)}");
+        }
+
+        private static string ExtractErrorMessage(string body)
+        {
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                return "no response body";
+            }
+            try
+            {
+                using var doc = JsonDocument.Parse(body);
+                if (doc.RootElement.ValueKind == JsonValueKind.Object)
+                {
+                    if (doc.RootElement.TryGetProperty("error", out var err) && err.ValueKind == JsonValueKind.String)
+                    {
+                        return err.GetString() ?? body;
+                    }
+                    if (doc.RootElement.TryGetProperty("message", out var msg) && msg.ValueKind == JsonValueKind.String)
+                    {
+                        return msg.GetString() ?? body;
+                    }
+                }
+            }
+            catch (JsonException)
+            {
+            }
+            return body;
         }
 
         private static string EncodeBasicAuth(string account, string apiKey)

--- a/src/plugin.validation.dns.simply/Simply/SimplyDnsClient.cs
+++ b/src/plugin.validation.dns.simply/Simply/SimplyDnsClient.cs
@@ -67,7 +67,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Simply
         private async Task<List<Product>> GetProductsAsync()
         {
             using var response = await _httpClient.GetAsync(_baseUrl + "/my/products/");
-            await EnsureSuccessOrThrowAsync(response, "GET /my/products/");
+            EnsureSuccessOrThrow(response, "GET /my/products/");
             await using var stream = await response.Content.ReadAsStreamAsync();
             var products = await JsonSerializer.DeserializeAsync<ProductList>(stream);
             if (products == null || products.Products == null)
@@ -81,19 +81,19 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Simply
         {
             using var content = new StringContent(JsonSerializer.Serialize(record), Encoding.UTF8, "application/json");
             using var response = await _httpClient.PostAsync(_baseUrl + $"/my/products/{WebUtility.UrlEncode(objectId)}/dns/records/", content);
-            await EnsureSuccessOrThrowAsync(response, "POST /dns/records/");
+            EnsureSuccessOrThrow(response, "POST /dns/records/");
         }
 
         private async Task DeleteRecordAsync(string objectId, int recordId)
         {
             using var response = await _httpClient.DeleteAsync(_baseUrl + $"/my/products/{WebUtility.UrlEncode(objectId)}/dns/records/{recordId}/");
-            await EnsureSuccessOrThrowAsync(response, $"DELETE /dns/records/{recordId}/");
+            EnsureSuccessOrThrow(response, $"DELETE /dns/records/{recordId}/");
         }
 
         private async Task<List<DnsRecord>> GetRecordsAsync(string objectId)
         {
             using var response = await _httpClient.GetAsync(_baseUrl + $"/my/products/{WebUtility.UrlEncode(objectId)}/dns/records/");
-            await EnsureSuccessOrThrowAsync(response, "GET /dns/records/");
+            EnsureSuccessOrThrow(response, "GET /dns/records/");
             await using var stream = await response.Content.ReadAsStreamAsync();
             var records = await JsonSerializer.DeserializeAsync<DnsRecordList>(stream);
             if (records == null || records.Records == null)
@@ -103,42 +103,14 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Simply
             return records.Records;
         }
 
-        private static async Task EnsureSuccessOrThrowAsync(HttpResponseMessage response, string operation)
+        private static void EnsureSuccessOrThrow(HttpResponseMessage response, string operation)
         {
             if (response.IsSuccessStatusCode)
             {
                 return;
             }
-            var body = await response.Content.ReadAsStringAsync();
             throw new HttpRequestException(
-                $"Simply.com API error ({operation}, HTTP {(int)response.StatusCode}): {ExtractErrorMessage(body)}");
-        }
-
-        private static string ExtractErrorMessage(string body)
-        {
-            if (string.IsNullOrWhiteSpace(body))
-            {
-                return "no response body";
-            }
-            try
-            {
-                using var doc = JsonDocument.Parse(body);
-                if (doc.RootElement.ValueKind == JsonValueKind.Object)
-                {
-                    if (doc.RootElement.TryGetProperty("error", out var err) && err.ValueKind == JsonValueKind.String)
-                    {
-                        return err.GetString() ?? body;
-                    }
-                    if (doc.RootElement.TryGetProperty("message", out var msg) && msg.ValueKind == JsonValueKind.String)
-                    {
-                        return msg.GetString() ?? body;
-                    }
-                }
-            }
-            catch (JsonException)
-            {
-            }
-            return body;
+                $"Simply.com API {operation} failed: HTTP {(int)response.StatusCode} {response.ReasonPhrase}");
         }
 
         private static string EncodeBasicAuth(string account, string apiKey)

--- a/src/plugin.validation.dns.simply/Simply/SimplyDnsClient.cs
+++ b/src/plugin.validation.dns.simply/Simply/SimplyDnsClient.cs
@@ -38,21 +38,30 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Simply
             });
         }
 
-        public async Task DeleteRecordAsync(string objectId, string domain, string value)
+        public async Task DeleteRecordAsync(Product product, string domain, string value)
         {
-            var products = await GetProductsAsync();
-            var product = products.FirstOrDefault(x => x.Object == objectId);
-            if (product == null)
+            if (string.IsNullOrEmpty(product.Object))
             {
-                throw new Exception($"Unable to find product with object id {objectId}.");
+                throw new InvalidOperationException("Product has no object id");
             }
-            var records = await GetRecordsAsync(objectId);
-            var record = records.SingleOrDefault(x => x.Type == "TXT" && $"{x.Name}.{product.Domain?.NameIdn ?? "unknown"}" == domain && x.Data == value);
-            if (record is null)
+            var zoneName = product.Domain?.NameIdn ?? product.Domain?.Name;
+            if (string.IsNullOrEmpty(zoneName))
             {
-                throw new Exception($"The TXT record {domain} that should be deleted does not exist at Simply.");
+                throw new InvalidOperationException($"Product {product.Object} has no domain name");
             }
-            await DeleteRecordAsync(objectId, record.RecordId);
+
+            var records = await GetRecordsAsync(product.Object);
+            var matching = records
+                .Where(x => x.Type == "TXT" && $"{x.Name}.{zoneName}" == domain && x.Data == value)
+                .ToList();
+
+            // ACME cleanup must be idempotent. If a previous run already
+            // removed the record (or the create step failed before adding
+            // it) there is nothing to delete and that is a success.
+            foreach (var record in matching)
+            {
+                await DeleteRecordAsync(product.Object, record.RecordId);
+            }
         }
 
         private async Task<List<Product>> GetProductsAsync()

--- a/src/plugin.validation.dns.simply/Simply/SimplyDnsClient.cs
+++ b/src/plugin.validation.dns.simply/Simply/SimplyDnsClient.cs
@@ -67,7 +67,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Simply
         private async Task<List<Product>> GetProductsAsync()
         {
             using var response = await _httpClient.GetAsync(_baseUrl + "/my/products/");
-            EnsureSuccessOrThrow(response, "GET /my/products/");
+            await EnsureSuccessOrThrowAsync(response, "GET /my/products/");
             await using var stream = await response.Content.ReadAsStreamAsync();
             var products = await JsonSerializer.DeserializeAsync<ProductList>(stream);
             if (products == null || products.Products == null)
@@ -81,19 +81,19 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Simply
         {
             using var content = new StringContent(JsonSerializer.Serialize(record), Encoding.UTF8, "application/json");
             using var response = await _httpClient.PostAsync(_baseUrl + $"/my/products/{WebUtility.UrlEncode(objectId)}/dns/records/", content);
-            EnsureSuccessOrThrow(response, "POST /dns/records/");
+            await EnsureSuccessOrThrowAsync(response, "POST /dns/records/");
         }
 
         private async Task DeleteRecordAsync(string objectId, int recordId)
         {
             using var response = await _httpClient.DeleteAsync(_baseUrl + $"/my/products/{WebUtility.UrlEncode(objectId)}/dns/records/{recordId}/");
-            EnsureSuccessOrThrow(response, $"DELETE /dns/records/{recordId}/");
+            await EnsureSuccessOrThrowAsync(response, $"DELETE /dns/records/{recordId}/");
         }
 
         private async Task<List<DnsRecord>> GetRecordsAsync(string objectId)
         {
             using var response = await _httpClient.GetAsync(_baseUrl + $"/my/products/{WebUtility.UrlEncode(objectId)}/dns/records/");
-            EnsureSuccessOrThrow(response, "GET /dns/records/");
+            await EnsureSuccessOrThrowAsync(response, "GET /dns/records/");
             await using var stream = await response.Content.ReadAsStreamAsync();
             var records = await JsonSerializer.DeserializeAsync<DnsRecordList>(stream);
             if (records == null || records.Records == null)
@@ -103,14 +103,49 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Simply
             return records.Records;
         }
 
-        private static void EnsureSuccessOrThrow(HttpResponseMessage response, string operation)
+        private static async Task EnsureSuccessOrThrowAsync(HttpResponseMessage response, string operation)
         {
             if (response.IsSuccessStatusCode)
             {
                 return;
             }
+            var detail = await TryReadMessageAsync(response);
+            var prefix = $"Simply.com API {operation} failed: HTTP {(int)response.StatusCode} {response.ReasonPhrase}";
             throw new HttpRequestException(
-                $"Simply.com API {operation} failed: HTTP {(int)response.StatusCode} {response.ReasonPhrase}");
+                string.IsNullOrEmpty(detail) ? prefix : $"{prefix}: {detail}");
+        }
+
+        private static async Task<string?> TryReadMessageAsync(HttpResponseMessage response)
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                return null;
+            }
+            try
+            {
+                using var doc = JsonDocument.Parse(body);
+                if (doc.RootElement.ValueKind == JsonValueKind.Object)
+                {
+                    // Simply error responses are {"error": "..."}.
+                    // The "status" field is hardcoded 200 even on errors,
+                    // so trust the HTTP status code, not the body.
+                    if (doc.RootElement.TryGetProperty("error", out var err) &&
+                        err.ValueKind == JsonValueKind.String)
+                    {
+                        return err.GetString();
+                    }
+                    if (doc.RootElement.TryGetProperty("message", out var msg) &&
+                        msg.ValueKind == JsonValueKind.String)
+                    {
+                        return msg.GetString();
+                    }
+                }
+            }
+            catch (JsonException)
+            {
+            }
+            return null;
         }
 
         private static string EncodeBasicAuth(string account, string apiKey)

--- a/src/plugin.validation.dns.simply/Simply/SimplyDnsClient.cs
+++ b/src/plugin.validation.dns.simply/Simply/SimplyDnsClient.cs
@@ -57,7 +57,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Simply
 
         private async Task<List<Product>> GetProductsAsync()
         {
-            using var response = await _httpClient.GetAsync(_baseUrl + "/my/products");
+            using var response = await _httpClient.GetAsync(_baseUrl + "/my/products/");
             await using var stream = await response.Content.ReadAsStreamAsync();
             var products = await JsonSerializer.DeserializeAsync<ProductList>(stream);
             if (products == null || products.Products == null)
@@ -70,21 +70,21 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins.Simply
         private async Task CreateRecordAsync(string objectId, DnsRecord record)
         {
             using var content = new StringContent(JsonSerializer.Serialize(record), Encoding.UTF8, "application/json");
-            using var response = await _httpClient.PostAsync(_baseUrl + $"/my/products/{WebUtility.UrlEncode(objectId)}/dns/records", content);
+            using var response = await _httpClient.PostAsync(_baseUrl + $"/my/products/{WebUtility.UrlEncode(objectId)}/dns/records/", content);
             var responseBody = await response.Content.ReadAsStringAsync();
             _ = response.EnsureSuccessStatusCode();
         }
 
         private async Task DeleteRecordAsync(string objectId, int recordId)
         {
-            using var response = await _httpClient.DeleteAsync(_baseUrl + $"/my/products/{WebUtility.UrlEncode(objectId)}/dns/records/{recordId}");
+            using var response = await _httpClient.DeleteAsync(_baseUrl + $"/my/products/{WebUtility.UrlEncode(objectId)}/dns/records/{recordId}/");
             var responseBody = await response.Content.ReadAsStringAsync();
             _ = response.EnsureSuccessStatusCode();
         }
 
         private async Task<List<DnsRecord>> GetRecordsAsync(string objectId)
         {
-            using var response = await _httpClient.GetAsync(_baseUrl + $"/my/products/{WebUtility.UrlEncode(objectId)}/dns/records");
+            using var response = await _httpClient.GetAsync(_baseUrl + $"/my/products/{WebUtility.UrlEncode(objectId)}/dns/records/");
             _ = response.EnsureSuccessStatusCode();
             await using var stream = await response.Content.ReadAsStreamAsync();
             var records = await JsonSerializer.DeserializeAsync<DnsRecordList>(stream);

--- a/src/plugin.validation.dns.simply/SimplyDnsValidation.cs
+++ b/src/plugin.validation.dns.simply/SimplyDnsValidation.cs
@@ -61,11 +61,7 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins
             {
                 var recordName = record.Authority.Domain;
                 var product = await GetProductAsync(recordName);
-                if (product.Object == null)
-                {
-                    throw new InvalidOperationException();
-                }
-                await _client.DeleteRecordAsync(product.Object, record.Authority.Domain, record.Value);
+                await _client.DeleteRecordAsync(product, record.Authority.Domain, record.Value);
             }
             catch (Exception ex)
             {
@@ -76,7 +72,11 @@ namespace PKISharp.WACS.Plugins.ValidationPlugins
         private async Task<Product> GetProductAsync(string recordName)
         {
             var products = await _client.GetAllProducts();
-            var product = FindBestMatch(products.ToDictionary(x => x.Domain?.NameIdn ?? "", x => x), recordName);
+            var byIdn = products
+                .Where(p => !string.IsNullOrEmpty(p.Domain?.NameIdn))
+                .GroupBy(p => p.Domain!.NameIdn!)
+                .ToDictionary(g => g.Key, g => g.First());
+            var product = FindBestMatch(byIdn, recordName);
             if (product is null)
             {
                 throw new Exception($"Unable to find product for record '{recordName}'");


### PR DESCRIPTION
A small bundle of fixes for the Simply.com DNS validation plugin.

### 1. Trailing slashes on every record endpoint

The Simply.com OpenAPI spec at https://api.simply.com/2/doc.json declares all the record endpoints with trailing slashes:

- `/my/products/`
- `/my/products/{object}/dns/records/`
- `/my/products/{object}/dns/records/{record_id}/`

The plugin called them without. Worked today, presumably via server-side redirects; safer to call them as documented.

### 2. Surface operation + HTTP status when a call fails

Every API method called `EnsureSuccessStatusCode()`, which throws `Response status code does not indicate success: 400 (Bad Request)` with no context about which call failed. The response body was actually being read into a discarded variable beforehand and then thrown away.

Replaced with a small helper that includes the operation and HTTP status + reason phrase:

```
Simply.com API POST /dns/records/ failed: HTTP 400 Bad Request
```

Just status code and reason — does not parse the response body for keys like `error`/`message`, since that body shape is not a stable contract.

### 3. Make ACME cleanup idempotent and drop redundant product fetch

Three bugs in `DeleteRecordAsync`:

- **Refetched the entire product list** just to find a product whose `Object` id the caller already had. Pass the `Product` through and skip the extra round-trip.
- **`SingleOrDefault` throws on duplicates.** If a prior cleanup failed and the record was re-added on retry, two matching TXT entries exist and the second cleanup crashed. Enumerate matches and delete each.
- **Threw on missing record.** ACME cleanup must be idempotent. A record that's already gone is a success, not a `Warning("Unable to delete record")` log entry. Silent return.

Also dropped the `?? "unknown"` zone-name fallback — throw early with a clear message if `Product.Domain` has no usable name.

In `SimplyDnsValidation.GetProductAsync`, the inline `ToDictionary(x => x.Domain?.NameIdn ?? "", ...)` threw `ArgumentException: An item with the same key has already been added: ''` if two products had null `Domain`. Replaced with `Where + GroupBy + ToDictionary`.

## Compatibility

- Public method signature on `SimplyDnsClient.DeleteRecordAsync` changes from `(string objectId, ...)` to `(Product product, ...)`. The class is in an internal plugin assembly with one known caller (`SimplyDnsValidation` in the same assembly), updated in the same commit.
- No config or options changes.

## Out of scope (intentional)

- The `EncodeBasicAuth` helper URL-encodes credentials before base64. Standard Basic Auth is base64 of raw `user:pass`. For typical alphanumeric API keys this is a no-op; for any key containing `+`, `/`, `=`, or non-ASCII the server would have to URL-decode the credentials, which is non-standard. Left alone since I can't verify behavior against a live API key from where I work, but flagging as a follow-up.

## Test plan

- [ ] CI builds.
- [ ] Manual: obtain a cert against a real Simply.com account with both a successful path and a forced-failure path (e.g., delete the TXT record manually between Present and CleanUp) to verify idempotent cleanup.

I do not have a Windows / .NET SDK on the host I wrote this from, so I have **not** run `dotnet build` or any tests locally. Please rely on CI / your local check, and I'm happy to fix anything that comes back.